### PR TITLE
chore(git): add gitattributes and force the following filetypes to have unix eols

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+# Separate configuration for files without suffix
+LICENSE text eol=lf
+commit-msg eol=lf
+pre-commit eol=lf
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png binary
+*.ico binary


### PR DESCRIPTION
解决windows下克隆项目自动转为CRLF换行，导致与eslint冲突