### PR TITLE
fix: avoid combining `globs` with `path.join()`

### DIFF
--- a/packages/vlib-ui/scripts/build/task/build-style.ts
+++ b/packages/vlib-ui/scripts/build/task/build-style.ts
@@ -15,7 +15,7 @@ import { generatePaths } from '../utils/rollup'
  */
 const buildScssCopy = async () => {
   await new Promise((resolve) => {
-    src(`${compRoot}/**/*.scss`)
+    src('**/*.scss', { cwd: compRoot })
       .pipe(dest(outputEsm))
       .pipe(dest(outputCjs))
       .on('end', resolve)
@@ -28,7 +28,7 @@ const buildScssCopy = async () => {
 const buildScssModules = async () => {
   const sass = gulpSass(dartSass)
   await new Promise((resolve) => {
-    src(`${compRoot}/**/style/*.scss`)
+    src('**/style/*.scss', { cwd: compRoot })
       .pipe(sass.sync())
       .pipe(autoprefixer({ cascade: false }))
       .pipe(cleanCSS())
@@ -44,7 +44,7 @@ const buildScssModules = async () => {
 const buildScssFull = async () => {
   const sass = gulpSass(dartSass)
   await new Promise((resolve) => {
-    src(`${compRoot}/*.scss`)
+    src('*.scss', { cwd: compRoot })
       .pipe(sass.sync())
       .pipe(autoprefixer({ cascade: false }))
       .pipe(cleanCSS())
@@ -59,7 +59,11 @@ const buildScssFull = async () => {
 const buildStyleModules = async () => {
   const input = [
     // style
-    ...(await glob(`${compRoot}/**/style/*.ts`)),
+    ...(await glob('**/style/*.ts', {
+      cwd: compRoot,
+      absolute: true,
+      onlyFiles: true,
+    })),
     // resolver
     path.resolve(compRoot, 'resolver.ts'),
   ]

--- a/packages/vlib-ui/scripts/build/task/generate-helper.ts
+++ b/packages/vlib-ui/scripts/build/task/generate-helper.ts
@@ -68,9 +68,14 @@ export const generateHelper = async () => {
     // 基本配置
     name: PKG_NAME,
     version,
-    entry: `${compRoot}/**/*.md`,
+    entry: `**/*.md`,
     outDir: output,
     space: 2,
+    fastGlobConfig: {
+      cwd: compRoot,
+      absolute: true,
+      onlyFiles: true,
+    },
 
     // 解析配置
     reComponentName,

--- a/packages/vlib-ui/scripts/build/task/generate-types.ts
+++ b/packages/vlib-ui/scripts/build/task/generate-types.ts
@@ -8,8 +8,8 @@ export const generateTypes = async () => {
   })
 
   await new Promise((resolve) => {
-    src(`${outputEsm}/**/*.d.ts`)
-      .pipe(dest(`${outputCjs}`))
+    src('**/*.d.ts', { cwd: outputEsm })
+      .pipe(dest(outputCjs))
       .on('end', resolve)
   })
 }


### PR DESCRIPTION
- 修复 #18 
- 修复 #21 
- 修复掘金文章 [打包篇一](https://juejin.cn/post/7137902538103193613)，[打包篇二](https://juejin.cn/post/7138212982558818311)，[打包篇三](https://juejin.cn/post/7138308389595152420) 下路径相关的问题评论。